### PR TITLE
📚 Added a disclaimer for second time signin user object 

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ const MyAppleSigninButton = () => (
 export default MyAppleSigninButton;
 ```
 
-##### :warning: Disclaimer
-``onSuccess`` response object will contain the user object on first time attempt. Meaning if you make another signin attempt you will not get the user object. This is true for third and N-th time attempt of the same account.
-
+##### Note about the response's `user` object
+`onSuccess` response object will contain the user object on the first time attempt only. Meaning if you make another signIn attempt for the same account you will not get the user object.
 ### Raw JS functionality
 a module called `appleAuthHelpers` is also exported to allow you to use the functionality without using the UI or relying on React. This works with any kind of frontend JS, eg: react, vue, etc...
 ```js


### PR DESCRIPTION
### Description:

I added a disclaimer which states that the user object will be returned on the response object of  ``onSuccess`` callback the first time and the second time it won't be available for the same account.