### PR TITLE
🐛 hotfix edge case of no click event

### DIFF
--- a/src/AppleSigninButton/AppleSigninButton.js
+++ b/src/AppleSigninButton/AppleSigninButton.js
@@ -77,8 +77,10 @@ const AppleSigninButton = ({
 
   /** Button click handler */
   const handleClick = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
+    if (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
     appleAuthHelpers.signIn({ authOptions, onSuccess, onError });
   };
 


### PR DESCRIPTION
### Description:
- Adds a conditional check for the click event before attempting to prevent default, this handles scenarios where there's no click event passed

closes https://github.com/A-Tokyo/react-apple-signin-auth/issues/61