### PR TITLE
⚡️ Remove async/await usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apple-signin-auth",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": " Apple signin for React using the official Apple JS SDK",
   "author": {
     "name": "Ahmed Tarek",

--- a/src/appleAuthHelpers/index.js
+++ b/src/appleAuthHelpers/index.js
@@ -17,36 +17,37 @@ const signIn = async ({
   authOptions: AppleAuthOptions,
   onSuccess?: Function,
   onError?: Function,
-}): Promise<?AppleAuthResponse> => {
-  try {
-    /** wait for apple sript to load */
-    await waitForVar('AppleID');
-    /** Handle if appleID script was not loaded -- log + throw error to be caught below */
-    if (!window.AppleID) {
-      console.error(new Error('Error loading apple script'));
-    }
-    /** Init apple auth */
-    window.AppleID.auth.init(authOptions);
-    /** Signin to appleID */
-    const response = await window.AppleID.auth.signIn();
-    /** This is only called in case usePopup is true */
-    if (onSuccess) {
-      onSuccess(response);
-    }
-    /** resolve with the reponse */
-    return response;
-  } catch (err) {
-    if (onError) {
-      /** Call onError catching the error */
-      onError(err);
-    } else {
-      /** Log the error to help debug */
-      console.error(err);
-    }
-  }
-  return null;
-};
+}): Promise<?AppleAuthResponse> =>
+  /** wait for apple sript to load */
+  waitForVar('AppleID')
+    .then(() => {
+      /** Handle if appleID script was not loaded -- log + throw error to be caught below */
+      if (!window.AppleID) {
+        console.error(new Error('Error loading apple script'));
+      }
+      /** Init apple auth */
+      window.AppleID.auth.init(authOptions);
+      /** Signin to appleID */
+      window.AppleID.auth.signIn().then((response) => {
+        /** This is only called in case usePopup is true */
+        if (onSuccess) {
+          onSuccess(response);
+        }
+        /** resolve with the reponse */
+        return response;
+      });
+    })
+    .catch((err) => {
+      if (onError) {
+        /** Call onError catching the error */
+        onError(err);
+      } else {
+        /** Log the error to help debug */
+        console.error(err);
+      }
 
+      return null;
+    });
 export default {
   APPLE_SCRIPT_SRC,
   signIn,

--- a/src/utils/waitForVar.js
+++ b/src/utils/waitForVar.js
@@ -8,7 +8,7 @@
  * - eg: `waitForVar('FB', { pollFrequency: 500, retries: 2, parent: window || global }).then(FB => FB.test())`
  * - eg: `waitForVar('FB', { retries: ({ retries } => retries * 500) }).then(FB => FB.test())`
  */
-const waitForVar = async (
+const waitForVar = (
   name,
   {
     pollFrequency = 1000,
@@ -22,21 +22,20 @@ const waitForVar = async (
 ) => {
   // eslint-disable-next-line no-prototype-builtins
   if (parent && parent.hasOwnProperty(name)) {
-    return parent[name];
+    return Promise.resolve(parent[name]);
   }
   if (!inRetries) {
-    return undefined;
+    return Promise.resolve(undefined);
   }
   const retries = inRetries - 1;
-  await new Promise((resolve) =>
+  return new Promise((resolve) =>
     setTimeout(
       resolve,
       typeof pollFrequency === 'function'
         ? pollFrequency({ retries })
         : pollFrequency,
     ),
-  );
-  return waitForVar(name, { pollFrequency, parent, retries });
+  ).then(() => waitForVar(name, { pollFrequency, parent, retries }));
 };
 
 export default waitForVar;


### PR DESCRIPTION
This resolves the issue where consumers of this library are expected to
include 'regenerator-runtime/runtime' even if they only support browsers
that have async/await support.