### PR TITLE
Remove async keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apple-signin-auth",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": " Apple signin for React using the official Apple JS SDK",
   "author": {
     "name": "Ahmed Tarek",

--- a/src/appleAuthHelpers/index.js
+++ b/src/appleAuthHelpers/index.js
@@ -9,7 +9,7 @@ const APPLE_SCRIPT_SRC: string =
 /**
  * Performs an apple ID signIn operation
  */
-const signIn = async ({
+const signIn = ({
   authOptions,
   onSuccess,
   onError,


### PR DESCRIPTION
I missed removing this async keyword which still makes the library require `regeneratorRuntime`