### PR TITLE
⚡️ Added missing catch block to promise

### DIFF
--- a/src/appleAuthHelpers/index.js
+++ b/src/appleAuthHelpers/index.js
@@ -35,6 +35,16 @@ const signIn = ({
         }
         /** resolve with the reponse */
         return response;
+      }).catch((err) => {
+        if (onError) {
+          /** Call onError catching the error */
+          onError(err);
+        } else {
+          /** Log the error to help debug */
+          console.error(err);
+        }
+  
+        return null;
       });
     })
     .catch((err) => {


### PR DESCRIPTION
### Description:
When a user manually closes the pop-up window, an error message is not picked up by a catch block. This can be seen in the console:
<img width="1728" alt="Screen Shot 2022-03-21 at 3 58 21 PM" src="https://user-images.githubusercontent.com/47458273/159354066-4995a7e0-2e06-48b3-9685-cc5249310cc2.png">

This PR adds the necessary catch block, allowing the error message to be properly passed into the `onError` callback.
 