### PR TITLE
:bug: hotfix issue 93 on error fires then page redirects popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Another library exists for server/backend support for Apple signin [apple-signin
 ### Related Projects
 - [Apple Signin for Node JS](https://github.com/A-Tokyo/apple-signin-auth)
 - [Apple Signin for React Native](https://github.com/invertase/react-native-apple-authentication)
+- [Supabase Docs: Build a Social Auth App with Expo React Native](https://supabase.com/docs/guides/auth/quickstarts/with-expo-react-native-social-auth)
 
 ## Contributing
 Pull requests are highly appreciated! For major changes, please open an issue first to discuss what you would like to change.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-apple-signin-auth",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": " Apple signin for React using the official Apple JS SDK",
   "author": {
     "name": "Ahmed Tarek",

--- a/src/appleAuthHelpers/appleAuthHelpers.test.js
+++ b/src/appleAuthHelpers/appleAuthHelpers.test.js
@@ -137,6 +137,56 @@ describe('appleAuthHelpers', () => {
     expect(response).toBeNull();
   });
 
+  it('should NOT call onError when signIn rejects and usePopup is false (redirect mode)', async () => {
+    window.AppleID = {
+      auth: {
+        init: AppleIDAuthInitFn,
+        signIn: () => Promise.reject(new Error('spurious redirect-mode error')),
+      },
+    };
+    const input = {
+      authOptions: { ..._authOptions, usePopup: false },
+      onError: jest.fn(),
+      onSuccess: jest.fn(),
+    };
+    const response = await appleAuthHelpers.signIn(input);
+    expect(response).toBeNull();
+    expect(input.onError).not.toHaveBeenCalled();
+    expect(input.onSuccess).not.toHaveBeenCalled();
+    expect(window.AppleID.auth.init).toHaveBeenCalled();
+  });
+
+  it('should NOT call onSuccess when signIn resolves and usePopup is false (redirect mode)', async () => {
+    const input = {
+      authOptions: { ..._authOptions, usePopup: false },
+      onError: jest.fn(),
+      onSuccess: jest.fn(),
+    };
+    const response = await appleAuthHelpers.signIn(input);
+    expect(response).toBeNull();
+    expect(input.onSuccess).not.toHaveBeenCalled();
+    expect(input.onError).not.toHaveBeenCalled();
+  });
+
+  it('should still call onError when init throws and usePopup is false', async () => {
+    window.AppleID = {
+      auth: {
+        init: () => {
+          throw new Error('init error');
+        },
+        signIn: AppleIDAuthSignInFn,
+      },
+    };
+    const input = {
+      authOptions: { ..._authOptions, usePopup: false },
+      onError: jest.fn(),
+    };
+    const response = await appleAuthHelpers.signIn(input);
+    expect(response).toBeNull();
+    expect(input.onError.mock.calls[0][0]).toEqual(expect.any(Error));
+    expect(input.onError.mock.calls[0][0].message).toEqual('init error');
+  });
+
   it('should call onSuccess upon success', async () => {
     const input = {
       authOptions: _authOptions,

--- a/src/appleAuthHelpers/index.js
+++ b/src/appleAuthHelpers/index.js
@@ -28,8 +28,21 @@ const signIn = ({
       /** Init apple auth */
       window.AppleID.auth.init(authOptions);
       /** Signin to appleID */
-      return window.AppleID.auth
-        .signIn()
+      const signInPromise = window.AppleID.auth.signIn();
+      /**
+       * In redirect mode (!usePopup) the Apple SDK navigates the page away.
+       * The returned promise can reject spuriously during/after navigation,
+       * which would flash onError before the redirect happens. Skip handlers
+       * in that case onSuccess/onError are popup-only by design.
+       */
+      if (!authOptions.usePopup) {
+        /** Swallow rejection to avoid unhandled promise warnings during navigation. */
+        if (signInPromise && typeof signInPromise.catch === 'function') {
+          signInPromise.catch(() => {});
+        }
+        return null;
+      }
+      return signInPromise
         .then((response) => {
           /** This is only called in case usePopup is true */
           if (onSuccess) {


### PR DESCRIPTION
### Description:
Issue: in redirect mode the Apple SDK starts a full-page navigation, and the `signIn()` promise can reject spuriously during/after that navigation, which flashes `onError` before the page actually navigates away.

Fix: when `authOptions.usePopup` is not true, the helper no longer attaches `.then`/`.catch` handlers to the `AppleID.auth.signIn()` promise

closes https://github.com/a-tokyo/react-apple-signin-auth/issues/93