### PR TITLE
:construction_worker: Pin GitHub Actions to SHAs and bump to Node 24 runtimes

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,8 +7,8 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: ahmadnassri/action-dependabot-auto-merge@45fc124d949b19b6b8bf6645b6c9d55f4f9ac61a # v2
         with:
           # major, minor, patch
           target: major

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -15,17 +15,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Get yarn cache
         id: yarn-cache
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ubuntu-latest-node-24.x-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ubuntu-latest-node-24.x-yarn-
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.x'
           registry-url: https://registry.npmjs.org/
@@ -33,7 +33,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Setup Chrome
         id: setup-chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2
       - name: Transpile library
         run: yarn transpile
       - name: Test
@@ -43,7 +43,7 @@ jobs:
         env:
           PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage
@@ -56,19 +56,19 @@ jobs:
     environment: production
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0
       - name: Get yarn cache
         id: yarn-cache
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ubuntu-latest-node-24.x-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ubuntu-latest-node-24.x-yarn-
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24.x'
           registry-url: https://registry.npmjs.org/
@@ -76,7 +76,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Setup Chrome
         id: setup-chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@2e1d749697dd1612b833dba4a722266286fbefcd # v2
       - name: Transpile library
         run: yarn transpile
       - name: Build demo
@@ -99,7 +99,7 @@ jobs:
           else
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
-      - uses: ncipollo/release-action@v1
+      - uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1
         if: steps.check_tag.outputs.exists == 'false'
         with:
           tag: ${{ env.PACKAGE_VERSION }}
@@ -109,7 +109,7 @@ jobs:
         if: steps.check_tag.outputs.exists == 'false'
         run: npm publish
       - name: Deploy Demo
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./demo/dist


### PR DESCRIPTION
## What

Converts the workflows' floating major tags to **full-commit-SHA pins** (with `# vN` comments) and bumps every action to its current major.

| Action | From | To |
|--------|------|----|
| `actions/checkout` | v4 / v2 | v7 |
| `actions/cache` | v4 | v5 |
| `actions/setup-node` | v4 | v6 |
| `browser-actions/setup-chrome` | v1 | v2 |
| `codecov/codecov-action` | v5 | v7 |
| `peaceiris/actions-gh-pages` | v4 | v4 (pinned) |
| `ncipollo/release-action` | v1 | v1 (pinned) |
| `ahmadnassri/action-dependabot-auto-merge` | v2 | v2 (pinned) |

## Why

GitHub is [deprecating the Node.js 20 runtime](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) for Actions; `actions/*@v4` bundle Node 20, and `automerge.yml` even used `actions/checkout@v2` (Node 16). Bumping to current majors moves everything onto Node 24 (or composite/docker). SHA-pinning matches the convention used in the sibling `apple-signin-auth` repo and hardens against tag-movement supply-chain risk.

## Notes

- All target SHAs resolved live from each action's current major tag; every target runs on `node24`, `composite`, or `docker` — none on Node 20.
- Major bumps verified non-breaking: `setup-chrome` v2 retains the `chrome-path` output; codecov v7 retains `token`/`directory` inputs.
- No step logic, inputs, or `node-version: '24.x'` changed.